### PR TITLE
File writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 backend/__pycache__
 *.nix
+/backend/.venew_jsonnew_json
+.zed/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 backend/__pycache__
+*.nix

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 ADJ Valet is the packet creator helper for the Control Station's ADJ.
 
-## Requirements
+## Usage - Nix
+
+Run the nix terminal and use the alias to `run-backend` and then `run-frontend`.
+
+## Usage - Manual
+
+### Requirements
 
 Python 3, fastapi\[standard\]
 
@@ -12,7 +18,7 @@ https://www.python.org/downloads/
 pip3 install "fastapi[standard]"
 ```
 
-## Start up
+### Start up
 
 To start the app, go to `adj-valet/backend` and run `uvicorn api:app --host localhost --port 8000`, move to `adj-valet/adj-valet-front` and run `npm i && npm run dev`
 

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+
 from path import ADJ_PATH
 from json_assembler import assemble_monojson
 from diff_merge import merge_changes
@@ -28,6 +29,7 @@ async def assemble_json():
     if ADJ_PATH.value is None:
         raise HTTPException(status_code=400, detail="ADJ_PATH is not set.")
     monojson = assemble_monojson(ADJ_PATH.value)
+    print(monojson)
     return monojson
 
 @app.post("/update")
@@ -38,7 +40,9 @@ async def update_json(request: Request):
     current_json = assemble_monojson(ADJ_PATH.value)
     new_json = merge_changes(current_json, updated_fields)
 
+    # Persist merged changes back into ADJ folder
     save_general_info(ADJ_PATH.value, new_json["general_info"])
-    save_board_list(ADJ_PATH.value, new_json["board_list"])
-    save_boards(ADJ_PATH.value, new_json["boards"])
-    return new_json
+    save_board_list(   ADJ_PATH.value, new_json["board_list"])
+    save_boards(       ADJ_PATH.value, new_json["boards"])
+
+    return assemble_monojson(ADJ_PATH.value)

--- a/backend/api.py
+++ b/backend/api.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from path import ADJ_PATH
 from json_assembler import assemble_monojson
 from diff_merge import merge_changes
+from file_writer import save_general_info, save_board_list, save_boards
 
 app = FastAPI()
 
@@ -36,4 +37,8 @@ async def update_json(request: Request):
         raise HTTPException(status_code=400, detail="ADJ_PATH is not set.")
     current_json = assemble_monojson(ADJ_PATH.value)
     new_json = merge_changes(current_json, updated_fields)
+
+    save_general_info(ADJ_PATH.value, new_json["general_info"])
+    save_board_list(ADJ_PATH.value, new_json["board_list"])
+    save_boards(ADJ_PATH.value, new_json["boards"])
     return new_json

--- a/backend/diff_merge.py
+++ b/backend/diff_merge.py
@@ -1,46 +1,96 @@
 from typing import Any, Dict
 
+
 def deep_merge(original: Any, updates: Any) -> Any:
+    # If the update itself is None, skip merging
+    if updates is None:
+        return original
+
+    # 1) Dict vs dict: merge recursively, skipping None values
     if isinstance(original, dict) and isinstance(updates, dict):
         for key, value in updates.items():
+            if value is None:
+                # skip null updates so we don't overwrite valid originals
+                continue
             if key in original:
                 original[key] = deep_merge(original[key], value)
             else:
                 original[key] = value
         return original
+
+    # 2) List vs list: handle wrappers or ID-based items
     elif isinstance(original, list) and isinstance(updates, list):
+        # a) single-key dict wrappers (e.g., boards)
         if original and isinstance(original[0], dict) and len(original[0]) == 1:
-            orig_dict = {list(item.keys())[0]: item for item in original}
+            orig_map = {list(item.keys())[0]: item for item in original}
             for upd_item in updates:
-                upd_key = list(upd_item.keys())[0]
-                if upd_key in orig_dict:
-                    orig_dict[upd_key] = deep_merge(orig_dict[upd_key], upd_item[upd_key])
+                if not isinstance(upd_item, dict) or not upd_item:
+                    continue
+                key = list(upd_item.keys())[0]
+                if key in orig_map:
+                    orig_map[key] = deep_merge(orig_map[key], upd_item)
                 else:
-                    orig_dict[upd_key] = upd_item[upd_key]
-            return [{k: v} for k, v in orig_dict.items()]
-        else:
-            def get_id(item: Any):
-                if isinstance(item, dict):
-                    for key in ['id', 'packet_id']:
-                        if key in item:
-                            return item[key]
-                return None
+                    orig_map[key] = upd_item
+            return [{k: v} for k, v in orig_map.items()]
 
-            orig_map = {}
-            for item in original:
-                item_id = get_id(item)
-                if item_id is not None:
-                    orig_map[item_id] = item
+        # b) ID-based list items
+        def get_id(item: Any):
+            if isinstance(item, dict):
+                for k in ("id", "packet_id"):
+                    if k in item:
+                        return item[k]
+            return None
 
-            for upd_item in updates:
-                upd_id = get_id(upd_item)
-                if upd_id is not None and upd_id in orig_map:
-                    orig_map[upd_id] = deep_merge(orig_map[upd_id], upd_item)
-                else:
-                    original.append(upd_item)
-            return original
+        # build index of hashable IDs
+        orig_map: Dict[Any, Any] = {}
+        for item in original:
+            uid = get_id(item)
+            if uid is None:
+                continue
+            try:
+                orig_map[uid] = item
+            except TypeError:
+                continue
+
+        merged = list(original)
+        for upd_item in updates:
+            uid = get_id(upd_item)
+            # skip null or invalid updates
+            if upd_item is None or uid is None:
+                continue
+            if uid in orig_map:
+                orig_map[uid] = deep_merge(orig_map[uid], upd_item)
+            else:
+                merged.append(upd_item)
+        return merged
+
+    # 3) Primitives: attempt best-effort type preservation
     else:
+        # boolean coercion
+        if isinstance(original, bool) and isinstance(updates, str):
+            low = updates.lower().strip()
+            if low in ("true", "1", "yes", "on"):
+                return True
+            if low in ("false", "0", "no", "off"):
+                return False
+
+        # integer coercion
+        if isinstance(original, int) and isinstance(updates, str):
+            try:
+                return int(updates.strip(), 0)
+            except ValueError:
+                pass
+
+        # float coercion
+        if isinstance(original, float) and isinstance(updates, str):
+            try:
+                return float(updates.strip())
+            except ValueError:
+                pass
+
+        # otherwise, overwrite
         return updates
+
 
 def merge_changes(original: Dict[str, Any], updates: Dict[str, Any]) -> Dict[str, Any]:
     return deep_merge(original, updates)

--- a/backend/file_writer.py
+++ b/backend/file_writer.py
@@ -1,0 +1,50 @@
+import os
+import json
+from typing import Any, Dict, List
+
+def save_general_info(adj_path: str, general_info: Dict[str, Any]) -> None:
+    path = os.path.join(adj_path, "general_info.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(general_info, f, indent=2)
+
+def save_board_list(adj_path: str, board_list: Dict[str, str]) -> None:
+    path = os.path.join(adj_path, "boards.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(board_list, f, indent=2)
+
+def save_boards(adj_path: str, boards: List[Dict[str, Any]]) -> None:
+    """
+    Expects boards in the form:
+      [ { "BoardA": { "board_id": ..., "board_ip": ..., "measurements": [...], "packets": [...] } }, ... ]
+    This will overwrite each board’s main file and drop all measurements/packets
+    into single JSON files under each board folder.
+    """
+    boards_root = os.path.join(adj_path, "boards")
+    for board_wrapper in boards:
+        board_name, board_obj = next(iter(board_wrapper.items()))
+        board_dir = os.path.join(boards_root, board_name)
+        if not os.path.isdir(board_dir):
+            raise FileNotFoundError(f"Boards directory not found: {board_dir}")
+
+        meas_path = os.path.join(board_dir, "measurements.json")
+        with open(meas_path, "w", encoding="utf-8") as mf:
+            json.dump(board_obj.get("measurements", []), mf, indent=2)
+
+        pkt_path = os.path.join(board_dir, "packets.json")
+        packets = [
+            { **v } for pkt in board_obj.get("packets", [])
+                   for v in [ pkt.get("packet_id", {}) ]
+        ]
+        with open(pkt_path, "w", encoding="utf-8") as pf:
+            json.dump(packets, pf, indent=2)
+
+        main_json_path = os.path.join(board_dir, f"{board_name}.json")
+        with open(main_json_path, "r+", encoding="utf-8") as f:
+            board_main = json.load(f)
+            board_main["board_id"]   = board_obj.get("board_id")
+            board_main["board_ip"]   = board_obj.get("board_ip")
+            board_main["measurements"] = ["measurements.json"]
+            board_main["packets"]      = ["packets.json"]
+            f.seek(0)
+            json.dump(board_main, f, indent=2)
+            f.truncate()


### PR DESCRIPTION
Refactor backend merge & persistence logic

- In `diff_merge.deep_merge`, skip `None` updates so that null form fields on update no longer overwrite existing values.
- Enhance primitive coercion to more reliably cast strings back to ints/floats/bools.
- In `json_assembler`, include each board’s `firmware` array in the assembled JSON payload.
- In `file_writer.save_boards`, preserve the `firmware` field when rewriting each board’s main JSON file.
- Update the `/update` endpoint to re-run `assemble_monojson` and return the full, canonical JSON—preventing the client from seeing temporary `null` values.